### PR TITLE
feat: Change python3 -m to compote (new CLI) (PACMAN-545)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye
 
-RUN pip install idf-component-manager~=1.1
+RUN pip install idf-component-manager~=1.2
 
 COPY upload.sh /upload.sh
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ jobs:
 
 ## Parameters
 
-| Input            | Optional | Default   | Description                                                                                                                    |
-| ---------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| api_token        | ❌       |           | API Token for the component registry                                                                                           |
-| namespace        | ❌       |           | Component namespace                                                                                                            |
-| name             | ✔ / ❌   |           | Name is required for uploading a component from the root of the repository                                                     |
-| version          | ✔        |           | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3` |
-| directories      | ✔        | Repo root | Semicolon separated list of directories with components.                                                                       |
-| skip_pre_release | ✔        | False     | Flag to skip [pre-release](https://semver.org/#spec-item-9) versions                                                           |
-| service_url      | ✔        |           | IDF Component registry API URL, default https://api.components.espressif.com/                                                  |
+| Input            | Optional | Default                              | Description                                                                                                                    |
+|------------------|----------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| api_token        | ❌        |                                      | API Token for the component registry                                                                                           |
+| namespace        | ❌        |                                      | Component namespace                                                                                                            |
+| name             | ✔ / ❌    |                                      | Name is required for uploading a component from the root of the repository                                                     |
+| version          | ✔        |                                      | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3` |
+| directories      | ✔        | Repo root                            | Semicolon separated list of directories with components.                                                                       |
+| skip_pre_release | ✔        | False                                | Flag to skip [pre-release](https://semver.org/#spec-item-9) versions                                                           |
+| service_url      | ✔        | https://components.espressif.com/api | (Deprecated) IDF Component registry API URL                                                                                    |
+| registry_url     | ✔        | https://components.espressif.com/    | IDF Component registry URL                                                                                                     |

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   service_url:
     description: "Component registry API endpoint"
     required: false
+  registry_url:
+    description: "Component registry endpoint"
+    required: false
   skip_pre_release:
     description: "Flag to skip pre-release versions. Set it to any non-empty string to skip pre-release versions."
     required: false
@@ -37,4 +40,5 @@ runs:
     COMPONENT_VERSION: ${{ inputs.version }}
     IDF_COMPONENT_API_TOKEN: ${{ inputs.api_token }}
     DEFAULT_COMPONENT_SERVICE_URL: ${{ inputs.service_url }}
+    IDF_COMPONENT_REGISTRY_URL: ${{ inputs.registry_url }}
     SKIP_PRE_RELEASE: ${{ inputs.skip_pre_release }}

--- a/upload.sh
+++ b/upload.sh
@@ -35,7 +35,7 @@ for ITEM in "${DIRECTORIES[@]}"; do
     fi
 
     echo "Processing component \"$NAME\" at $ITEM"
-    python3 -m idf_component_manager upload-component "${UPLOAD_ARGUMENTS[@]}" --path="${FULL_PATH}" --name="${NAME}"
+    compote component upload "${UPLOAD_ARGUMENTS[@]}" --project-dir="${FULL_PATH}" --name="${NAME}"
 
     EXIT_CODE=$?
     if [ "$EXIT_CODE" -ne "0" ]; then


### PR DESCRIPTION
Change `python3 -m idf_component_manager` command to `compote component upload`

Tested on https://github.com/magicarm22/example_components/actions/runs/3781762767/jobs/6429132436. Job started, command worked without errors, just an error with uploading component to the registry because I have no token for staging for now.