### PR TITLE
Pin urllib3 to <2 (temporary fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye
 
-RUN pip install idf-component-manager~=1.2
+RUN pip install "idf-component-manager~=1.2" "urllib3<2"
 
 COPY upload.sh /upload.sh
 


### PR DESCRIPTION
While the component manager with the fix is not released, this will help to avoid the problem like https://github.com/espressif/esp-zboss-lib/actions/runs/4893409680/jobs/8750304677