### PR TITLE
feat(action): add dry_run option for upload validation (PACMAN-669)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye
 
-RUN pip install "idf-component-manager~=1.2" "urllib3<2"
+RUN pip install "idf-component-manager~=1.3" "urllib3<2"
 
 COPY upload.sh /upload.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye
 
-RUN pip install "idf-component-manager~=1.3" "urllib3<2"
+RUN pip install "idf-component-manager~=1.3"
 
 COPY upload.sh /upload.sh
 

--- a/README.md
+++ b/README.md
@@ -80,5 +80,6 @@ jobs:
 | version          | ✔        |                                      | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3` |
 | directories      | ✔        | Repo root                            | Semicolon separated list of directories with components.                                                                       |
 | skip_pre_release | ✔        | False                                | Flag to skip [pre-release](https://semver.org/#spec-item-9) versions                                                           |
+| dry_run          | ✔        | False                                | Flag to upload a component for validation only without creating a version in the registry.                |
 | service_url      | ✔        | https://components.espressif.com/api | (Deprecated) IDF Component registry API URL                                                                                    |
 | registry_url     | ✔        | https://components.espressif.com/    | IDF Component registry URL                                                                                                     |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   skip_pre_release:
     description: "Flag to skip pre-release versions. Set it to any non-empty string to skip pre-release versions."
     required: false
+  dry_run:
+    description: "Upload component for validation without creating a version in the registry."
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -42,3 +45,4 @@ runs:
     DEFAULT_COMPONENT_SERVICE_URL: ${{ inputs.service_url }}
     IDF_COMPONENT_REGISTRY_URL: ${{ inputs.registry_url }}
     SKIP_PRE_RELEASE: ${{ inputs.skip_pre_release }}
+    DRY_RUN: ${{ inputs.dry_run }}

--- a/upload.sh
+++ b/upload.sh
@@ -6,6 +6,9 @@ UPLOAD_ARGUMENTS=("--allow-existing" "--namespace=${NAMESPACE}" )
 if [ -n "$SKIP_PRE_RELEASE" ]; then
     UPLOAD_ARGUMENTS+=("--skip-pre-release")
 fi
+if [ -n "$DRY_RUN" ]; then
+    UPLOAD_ARGUMENTS+=("--dry-run")
+fi
 
 if [ -n "$COMPONENT_VERSION" ]; then
     if [ "$COMPONENT_VERSION" == "git" ]; then


### PR DESCRIPTION
Expose the [--dry-run](https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/compote_cli.html#cmdoption-compote-component-upload-dry-run) command line option to the Github Action.