### PR TITLE
Fix dry run and  skip pre-release flags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: "3.0.0"
+    hooks:
+      - id: shellcheck

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ jobs:
 
 ## Parameters
 
-| Input            | Optional | Default                              | Description                                                                                                                    |
-|------------------|----------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| api_token        | ❌        |                                      | API Token for the component registry                                                                                           |
-| namespace        | ❌        |                                      | Component namespace                                                                                                            |
-| name             | ✔ / ❌    |                                      | Name is required for uploading a component from the root of the repository                                                     |
-| version          | ✔        |                                      | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3` |
-| directories      | ✔        | Repo root                            | Semicolon separated list of directories with components.                                                                       |
-| skip_pre_release | ✔        | False                                | Flag to skip [pre-release](https://semver.org/#spec-item-9) versions                                                           |
-| dry_run          | ✔        | False                                | Flag to upload a component for validation only without creating a version in the registry.                |
-| service_url      | ✔        | https://components.espressif.com/api | (Deprecated) IDF Component registry API URL                                                                                    |
-| registry_url     | ✔        | https://components.espressif.com/    | IDF Component registry URL                                                                                                     |
+| Input            | Optional | Default                              | Description                                                                                                                      |
+| ---------------- | -------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| api_token        | ❌       |                                      | API Token for the component registry                                                                                             |
+| namespace        | ❌       |                                      | Component namespace                                                                                                              |
+| name             | ✔ / ❌   |                                      | Name is required for uploading a component from the root of the repository                                                       |
+| version          | ✔        |                                      | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3`   |
+| directories      | ✔        | Repo root                            | Semicolon separated list of directories with components.                                                                         |
+| skip_pre_release | ✔        | False                                | Set this flag to `true`, `t`, `yes` or `1` to skip [pre-release](https://semver.org/#spec-item-9) versions.                      |
+| dry_run          | ✔        | False                                | Set this flag to `true`, `t`, `yes` or `1` to upload a component for validation only without creating a version in the registry. |
+| service_url      | ✔        | https://components.espressif.com/api | (Deprecated) IDF Component registry API URL                                                                                      |
+| registry_url     | ✔        | https://components.espressif.com/    | IDF Component registry URL                                                                                                       |

--- a/upload.sh
+++ b/upload.sh
@@ -3,10 +3,10 @@
 IFS=';' read -ra DIRECTORIES <<<"$(echo -e "${COMPONENTS_DIRECTORIES:-.}" | tr -d '[:space:]')"
 NAMESPACE=${COMPONENTS_NAMESPACE:-espressif}
 UPLOAD_ARGUMENTS=("--allow-existing" "--namespace=${NAMESPACE}" )
-if [ -n "$SKIP_PRE_RELEASE" ]; then
+if [[ "${SKIP_PRE_RELEASE,,}" =~ ^(true|t|yes|1)$ ]]; then
     UPLOAD_ARGUMENTS+=("--skip-pre-release")
 fi
-if [ -n "$DRY_RUN" ]; then
+if [[ "${DRY_RUN,,}" =~ ^(true|t|yes|1)$ ]]; then
     UPLOAD_ARGUMENTS+=("--dry-run")
 fi
 


### PR DESCRIPTION
Previously, any value for `dry_run` and `skip_pre_release` was considered as true, with this MR it's necessary to set the flag to `true`, `t`, `yes` or `1` (case-insensitive), to enable it.