### PR TITLE
feat: add repository and commit_id parameters (PACMAN-782)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
       - name: Upload component to the component registry
         uses: espressif/upload-components-ci-action@v1
         with:
@@ -46,7 +45,7 @@ jobs:
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
 ```
 
-#### Uploading multiple components from one repository
+#### Uploading multiple components from the current repository
 
 ```yaml
 name: Push components to https://components.espressif.com
@@ -58,10 +57,9 @@ jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
       - name: Upload components to the component registry
         uses: espressif/upload-components-ci-action@v1
         with:
@@ -70,16 +68,48 @@ jobs:
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
 ```
 
+#### Uploading a component through a workflow from a different repository
+
+```yaml
+name: Push component to https://components.espressif.com
+on:
+  push:
+    branches:
+      - main
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+          repository: "another/repository"
+      - name: Save information about repository to the github environment
+        run:
+          echo "GITHUB_REPOSITORY_URL=`git config --get remote.origin.url`" >> "$GITHUB_ENV";
+          echo "GITHUB_COMMIT_SHA=`git rev-parse HEAD`" >> "$GITHUB_ENV";
+      - name: Upload components to the component registry
+        uses: espressif/upload-components-ci-action@v1
+        with:
+          name: "example"
+          namespace: "espressif"
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+          repository_url: ${{ env.GITHUB_REPOSITORY_URL }}
+          commit_sha: ${{ env.GITHUB_COMMIT_SHA }}
+```
+
 ## Parameters
 
-| Input            | Optional | Default                              | Description                                                                                                                      |
-| ---------------- | -------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| api_token        | ❌       |                                      | API Token for the component registry                                                                                             |
-| namespace        | ❌       |                                      | Component namespace                                                                                                              |
-| name             | ✔ / ❌   |                                      | Name is required for uploading a component from the root of the repository                                                       |
-| version          | ✔        |                                      | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3`   |
-| directories      | ✔        | Repo root                            | Semicolon separated list of directories with components.                                                                         |
-| skip_pre_release | ✔        | False                                | Set this flag to `true`, `t`, `yes` or `1` to skip [pre-release](https://semver.org/#spec-item-9) versions.                      |
-| dry_run          | ✔        | False                                | Set this flag to `true`, `t`, `yes` or `1` to upload a component for validation only without creating a version in the registry. |
-| service_url      | ✔        | https://components.espressif.com/api | (Deprecated) IDF Component registry API URL                                                                                      |
-| registry_url     | ✔        | https://components.espressif.com/    | IDF Component registry URL                                                                                                       |
+| Input                  | Optional | Default                              | Description                                                                                                                            |
+|------------------------|----------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| api_token              | ❌        |                                      | API Token for the component registry                                                                                                   |
+| namespace              | ❌        |                                      | Component namespace                                                                                                                    |
+| name                   | ✔ / ❌    |                                      | Name is required for uploading a component from the root of the repository                                                             |
+| version                | ✔        |                                      | Version of the component, if not specified in the manifest. Should be a [semver](https://semver.org/) like `1.2.3` or `v1.2.3`         |
+| directories            | ✔        | Repo root                            | Semicolon separated list of directories with components.                                                                               |
+| skip_pre_release       | ✔        | False                                | Set this flag to `true`, `t`, `yes` or `1` to skip [pre-release](https://semver.org/#spec-item-9) versions.                            |
+| dry_run                | ✔        | False                                | Set this flag to `true`, `t`, `yes` or `1` to upload a component for validation only without creating a version in the registry.       |
+| service_url            | ✔        | https://components.espressif.com/api | (Deprecated) IDF Component registry API URL                                                                                            |
+| registry_url           | ✔        | https://components.espressif.com/    | IDF Component registry URL                                                                                                             |
+| repository_url         | ✔        | Current working repository           | URL of the repository where component is located. Set to empty string if you don't want to send the information about the repository.  |
+| commit_sha             | ✔        | Current commit sha                   | Git commit SHA of the the component version. Set to empty string if you don't want to send the information about the repository.       |

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
   dry_run:
     description: "Upload component for validation without creating a version in the registry."
     required: false
+  repository_url:
+    description: "URL of the repository where component is located"
+    required: false
+    default: ${{ github.repositoryUrl }}
+  commit_sha:
+    description: "Git commit SHA of the the component version"
+    required: false
+    default: ${{ github.sha }}
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -46,3 +54,5 @@ runs:
     IDF_COMPONENT_REGISTRY_URL: ${{ inputs.registry_url }}
     SKIP_PRE_RELEASE: ${{ inputs.skip_pre_release }}
     DRY_RUN: ${{ inputs.dry_run }}
+    REPOSITORY_URL: ${{ inputs.repository_url }}
+    REPOSITORY_COMMIT_SHA: ${{ inputs.commit_sha }}

--- a/upload.sh
+++ b/upload.sh
@@ -39,7 +39,24 @@ for ITEM in "${DIRECTORIES[@]}"; do
     fi
 
     echo "Processing component \"$NAME\" at $ITEM"
-    compote component upload "${UPLOAD_ARGUMENTS[@]}" --project-dir="${FULL_PATH}" --name="${NAME}"
+
+    PARAMS=("${UPLOAD_ARGUMENTS[@]}")
+    PARAMS+=("--project-dir=${FULL_PATH}" "--name=${NAME}" )
+
+
+    if [ -n "$REPOSITORY_URL" ]; then
+      PARAMS+=("--repository=${REPOSITORY_URL}")
+    fi
+
+    if [ -n "$REPOSITORY_COMMIT_SHA" ]; then
+      PARAMS+=("--commit-sha=${REPOSITORY_COMMIT_SHA}")
+    fi
+
+    if [ -n "$REPOSITORY_URL" ] && [ -n "$REPOSITORY_COMMIT_SHA" ]; then
+      PARAMS+=("--repository-path=${ITEM}")
+    fi
+
+    compote component upload "${PARAMS[@]}"
 
     EXIT_CODE=$?
     if [ "$EXIT_CODE" -ne "0" ]; then


### PR DESCRIPTION
This MR adds two params - repository and commit_id of the component. Example of the action:
https://github.com/magicarm22/example_component/actions/runs/7330486526/job/19962669349
It wrote an error because it is an old version of idf-component-manager. Command looks good:
```
compote component upload --allow-existing --namespace=dmitry --project-dir=/github/workspace/. --name=test_uploading_component --repository=git://github.com/magicarm22/example_component.git --commit-sha=c3ab451ac4294038efeda32404a6e9f9466de8da
```
