### PR TITLE
Implement v1 to v2 Migration Support for Upload Components Action

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov idf-component-manager==2.2.1
+          pip install pytest pytest-cov idf-component-manager
 
       - name: Run pytest with coverage
         run: |-

--- a/README.md
+++ b/README.md
@@ -175,3 +175,82 @@ jobs:
 | registry_url     | ✔        | https://components.espressif.com/ | IDF Component registry URL                                                                                                                                                                                                                                |
 | repository_url   | ✔        | Current working repository        | URL of the repository where component is located. Set to empty string if you don't want to send the information about the repository.                                                                                                                     |
 | commit_sha       | ✔        | Current commit SHA                | Git commit SHA of the component version. Set to empty string if you don't want to send the information about the repository.                                                                                                                              |
+
+## Upgrading from v1 to v2
+
+This section provides guidance on migrating from v1 to v2 of this action.
+
+### Key changes in v2
+
+1. **New `components` input**: Replaces the `name` and `directories` inputs with a more flexible format
+2. **Deprecated inputs**: `name` and `directories` are deprecated but still partially supported
+3. **Removed input**: `service_url` has been completely removed (it was previously deprecated in v1 in favor of `registry_url`)
+4. **Enhanced component specification**: Components can now be specified with custom names and paths
+
+### Migration guide
+
+#### Single component from repository root
+
+**v1 usage:**
+
+```yaml
+- uses: espressif/upload-components-ci-action@v1
+  with:
+    name: "my_component"
+    namespace: "espressif"
+    api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+```
+
+**v2 equivalent:**
+
+```yaml
+- uses: espressif/upload-components-ci-action@v2
+  with:
+    components: "my_component:."
+    namespace: "espressif"
+    api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+```
+
+#### Multiple components from directories
+
+**v1 usage:**
+
+```yaml
+- uses: espressif/upload-components-ci-action@v1
+  with:
+    directories: "components/my_component;components/another_component"
+    namespace: "espressif"
+    api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+```
+
+**v2 equivalent:**
+
+```yaml
+- uses: espressif/upload-components-ci-action@v2
+  with:
+    components: |
+      components/my_component
+      components/another_component
+    namespace: "espressif"
+    api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+```
+
+#### Service URL migration (if used in v1)
+
+**v1 usage (deprecated):**
+
+```yaml
+- uses: espressif/upload-components-ci-action@v1
+  with:
+    service_url: "https://components.espressif.com/api"
+    # ... other inputs
+```
+
+**v2 equivalent:**
+
+```yaml
+- uses: espressif/upload-components-ci-action@v2
+  with:
+    registry_url: "https://components.espressif.com/"
+    # ... other inputs
+```

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: 'Git commit SHA of the the component version'
     required: false
     default: ${{ github.sha }}
+  name:
+    description: '(Deprecated in v2, use components instead) Name is required for uploading a component from the root of the repository'
+    required: false
+    deprecationMessage: 'The name input is deprecated. Use the components input instead with format "component_name:." for root directory components.'
+  directories:
+    description: '(Deprecated in v2, use components instead) Semicolon separated list of directories with components'
+    required: false
+    deprecationMessage: 'The directories input is deprecated. Use the components input instead with format "directory_name" or "component_name:directory_name".'
 
 runs:
   using: 'docker'
@@ -51,3 +59,6 @@ runs:
     DRY_RUN: ${{ inputs.dry_run }}
     REPOSITORY_URL: ${{ inputs.repository_url }}
     REPOSITORY_COMMIT_SHA: ${{ inputs.commit_sha }}
+    # Deprecated inputs for backward compatibility
+    COMPONENT_NAME: ${{ inputs.name }}
+    COMPONENT_DIRECTORIES: ${{ inputs.directories }}

--- a/test_upload.py
+++ b/test_upload.py
@@ -52,8 +52,6 @@ def test_split_component_str(component_str, expected_name, expected_path):
             ("comp1:./comp1;\ncomp2:./comp2", [Component(name="comp1", path="./comp1"), Component(name="comp2", path="./comp2")]),
             # Component with extra spaces
             ("  comp1  :  ./  \n\n", [Component(name="comp1", path="./")]),
-            # Empty string should result in no components
-            ("", []),
             # Mixed empty parts and valid component (ignores empty entries)
             ("comp1;\n   ;\ncomp2:./comp2", [Component(name=None, path="comp1"), Component(name="comp2", path="./comp2")]),
         ],
@@ -92,9 +90,149 @@ def test_mock_version_if_provided_in_input():
 
 def test_mock_version_if_not_provided_even_in_manifest(tmp_path):
     (tmp_path / "idf_component.yml").touch()
-    assert mock_version_if_not_provided({}, tmp_path)['version'] == "1000.1000.1000"
+    result = mock_version_if_not_provided({}, tmp_path)['version']
+    assert result.startswith("1000.1000.1000-mock.")
 
 
 def test_mock_version_if_provided_in_manifest(tmp_path):
     (tmp_path / "idf_component.yml").write_text("version: 1.2.3")
     assert mock_version_if_not_provided({}, tmp_path) == {}
+
+# V1 to V2 Migration Tests
+def test_v2_format_components_input(monkeypatch):
+    """Test v2 format: components: "my_component:." """
+    monkeypatch.setenv("COMPONENTS", "my_component:.")
+    # Clear any legacy inputs
+    monkeypatch.delenv("COMPONENT_NAME", raising=False)
+    monkeypatch.delenv("COMPONENT_DIRECTORIES", raising=False)
+
+    result = parse_components_input()
+    expected = [Component(name="my_component", path=".")]
+    assert result == expected
+
+def test_v1_legacy_name_input(monkeypatch):
+    """Test v1 legacy: name: "my_component" """
+    # Clear new format
+    monkeypatch.delenv("COMPONENTS", raising=False)
+    # Set legacy name input
+    monkeypatch.setenv("COMPONENT_NAME", "my_component")
+    monkeypatch.delenv("COMPONENT_DIRECTORIES", raising=False)
+
+    result = parse_components_input()
+    expected = [Component(name="my_component", path=".")]
+    assert result == expected
+
+def test_v1_legacy_directories_input(monkeypatch):
+    """Test v1 legacy: directories: "components/comp1;components/comp2" """
+    # Clear new format
+    monkeypatch.delenv("COMPONENTS", raising=False)
+    # Set legacy directories input (semicolon-separated only)
+    monkeypatch.delenv("COMPONENT_NAME", raising=False)
+    monkeypatch.setenv("COMPONENT_DIRECTORIES", "components/comp1;components/comp2")
+
+    result = parse_components_input()
+    expected = [
+        Component(name=None, path="components/comp1"),
+        Component(name=None, path="components/comp2")
+    ]
+    assert result == expected
+
+def test_input_precedence_v2_over_legacy(monkeypatch, capsys):
+    """Test precedence: v2 components takes priority over legacy inputs with warning """
+    # Set both new and legacy inputs
+    monkeypatch.setenv("COMPONENTS", "new_component:.")
+    monkeypatch.setenv("COMPONENT_NAME", "legacy_component")
+
+    from upload import validate_input_precedence
+    validate_input_precedence()
+
+    # Check that warning is printed
+    captured = capsys.readouterr()
+    assert "WARNING: Both v2 'components' and legacy v1 inputs detected." in captured.out
+    assert "Using v2 'components' input. Legacy inputs will be ignored." in captured.out
+
+    # Verify v2 format takes precedence
+    result = parse_components_input()
+    expected = [Component(name="new_component", path=".")]
+    assert result == expected
+
+def test_conflicting_legacy_inputs_error(monkeypatch):
+    """Test error when both legacy name and directories are provided """
+    # Clear new format
+    monkeypatch.delenv("COMPONENTS", raising=False)
+    # Set both legacy inputs (should cause error)
+    monkeypatch.setenv("COMPONENT_NAME", "my_component")
+    monkeypatch.setenv("COMPONENT_DIRECTORIES", "components/comp1")
+
+    from upload import validate_input_precedence, FatalError
+
+    with pytest.raises(FatalError) as exc_info:
+        validate_input_precedence()
+
+    assert "Cannot use both 'name' and 'directories' legacy inputs simultaneously" in str(exc_info.value)
+
+def test_migration_guidance_for_legacy_name(monkeypatch, capsys):
+    """Test migration guidance is shown for legacy name input """
+    monkeypatch.setenv("COMPONENT_NAME", "my_component")
+    monkeypatch.delenv("COMPONENT_DIRECTORIES", raising=False)
+
+    from upload import provide_migration_guidance
+    provide_migration_guidance()
+
+    captured = capsys.readouterr()
+    assert "INFO: Detected legacy v1 inputs. Consider migrating to v2 format:" in captured.out
+    assert "v1: name: 'my_component'" in captured.out
+    assert "v2: components: 'my_component:.'" in captured.out
+    assert "See migration guide: https://github.com/espressif/upload-components-ci-action#upgrading-from-v1-to-v2" in captured.out
+
+def test_migration_guidance_for_legacy_directories(monkeypatch, capsys):
+    """Test migration guidance is shown for legacy directories input """
+    monkeypatch.delenv("COMPONENT_NAME", raising=False)
+    monkeypatch.setenv("COMPONENT_DIRECTORIES", "comp1;comp2")
+
+    from upload import provide_migration_guidance
+    provide_migration_guidance()
+
+    captured = capsys.readouterr()
+    assert "INFO: Detected legacy v1 inputs. Consider migrating to v2 format:" in captured.out
+    assert "v1: directories: 'comp1;comp2'" in captured.out
+    assert "comp1" in captured.out
+    assert "comp2" in captured.out
+    assert "See migration guide: https://github.com/espressif/upload-components-ci-action#upgrading-from-v1-to-v2" in captured.out
+
+def test_no_components_specified_error(monkeypatch):
+    """Test error when no components are specified """
+    # Clear all component inputs
+    monkeypatch.delenv("COMPONENTS", raising=False)
+    monkeypatch.delenv("COMPONENT_NAME", raising=False)
+    monkeypatch.delenv("COMPONENT_DIRECTORIES", raising=False)
+
+    from upload import FatalError
+
+    with pytest.raises(FatalError) as exc_info:
+        parse_components_input()
+
+    assert "No components specified. Use 'components' input or legacy 'name'/'directories' inputs." in str(exc_info.value)
+
+def test_legacy_inputs_return_none_when_no_legacy_set(monkeypatch):
+    """Test parse_legacy_inputs returns None when no legacy inputs are set """
+    monkeypatch.delenv("COMPONENT_NAME", raising=False)
+    monkeypatch.delenv("COMPONENT_DIRECTORIES", raising=False)
+
+    from upload import parse_legacy_inputs
+    result = parse_legacy_inputs()
+    assert result is None
+
+def test_legacy_directories_with_spaces_and_empty_entries(monkeypatch):
+    """Test legacy directories parsing handles spaces and empty entries correctly """
+    monkeypatch.delenv("COMPONENTS", raising=False)
+    monkeypatch.delenv("COMPONENT_NAME", raising=False)
+    monkeypatch.setenv("COMPONENT_DIRECTORIES", "comp1; comp2 ;; comp3 ;")
+
+    result = parse_components_input()
+    expected = [
+        Component(name=None, path="comp1"),
+        Component(name=None, path="comp2"),
+        Component(name=None, path="comp3")
+    ]
+    assert result == expected

--- a/test_upload.py
+++ b/test_upload.py
@@ -82,7 +82,8 @@ def test_args_to_list(input_args, expected):
 
 
 def test_mock_version_if_not_provided():
-    assert mock_version_if_not_provided({}, Path(''))["version"] == "1000.1000.1000"
+    result = mock_version_if_not_provided({}, Path(''))["version"]
+    assert result.startswith("1000.1000.1000-mock.")
 
 
 def test_mock_version_if_provided_in_input():

--- a/upload.py
+++ b/upload.py
@@ -56,9 +56,83 @@ def split_component_str(component_str: str) -> Component:
     return Component(name=name.strip(), path=path.strip())
 
 
+def parse_legacy_inputs() -> list[Component] | None:
+    """
+    Parse legacy v1 inputs (name and directories) for backward compatibility.
+    Returns None if no legacy inputs are found.
+    """
+    # Handle legacy 'name' input for single component in root
+    component_name = os.getenv('COMPONENT_NAME')
+
+    # Handle legacy 'directories' input for multiple components
+    directories_str = os.getenv('COMPONENT_DIRECTORIES')
+
+    if component_name and not directories_str:
+        # v1 single component in root scenario
+        return [Component(name=component_name, path='.')]
+
+    if directories_str and not component_name:
+        # v1 multiple directories scenario (semicolon-separated only)
+        return [Component(name=None, path=dir.strip()) for dir in directories_str.split(';') if dir.strip()]
+
+    return None
+
+
+def validate_input_precedence():
+    """
+    Validate input precedence and warn about conflicting inputs.
+    """
+    has_new_format = bool(os.getenv('COMPONENTS'))
+    has_legacy_name = bool(os.getenv('COMPONENT_NAME'))
+    has_legacy_dirs = bool(os.getenv('COMPONENT_DIRECTORIES'))
+
+    if has_new_format and (has_legacy_name or has_legacy_dirs):
+        print("WARNING: Both v2 'components' and legacy v1 inputs detected.")
+        print("Using v2 'components' input. Legacy inputs will be ignored.")
+
+    if has_legacy_name and has_legacy_dirs:
+        raise FatalError(
+            "Cannot use both 'name' and 'directories' legacy inputs simultaneously. "
+            "Use 'name' for single component in root, or 'directories' for multiple components."
+        )
+
+
+def provide_migration_guidance():
+    """
+    Provide helpful migration guidance for common v1 to v2 issues.
+    """
+    component_name = os.getenv('COMPONENT_NAME')
+    directories = os.getenv('COMPONENT_DIRECTORIES')
+
+    if component_name or directories:
+        print('INFO: Detected legacy v1 inputs. Consider migrating to v2 format:')
+        if component_name:
+            print(f"  v1: name: '{component_name}'")
+            print(f"  v2: components: '{component_name}:.'")
+        if directories:
+            print(f"  v1: directories: '{directories}'")
+            dirs_list = [d.strip() for d in directories.split(';') if d.strip()]
+            v2_format = '\n'.join([f'    {d}' for d in dirs_list])
+            print(f'  v2: components: |\n{v2_format}')
+        print('  See migration guide: https://github.com/espressif/upload-components-ci-action#upgrading-from-v1-to-v2')
+
+
 def parse_components_input() -> list[Component]:
-    dirs_str = str(os.environ['COMPONENTS'])
-    return [split_component_str(component) for component in re.split('[;\n]', dirs_str) if component.strip()]
+    """
+    Parse components input with backward compatibility for v1 inputs.
+    """
+    # Try new v2 format first
+    components_str = os.getenv('COMPONENTS')
+    if components_str:
+        return [split_component_str(component) for component in re.split('[;\n]', components_str) if component.strip()]
+
+    # Fall back to legacy v1 inputs
+    legacy_components = parse_legacy_inputs()
+    if legacy_components:
+        return legacy_components
+
+    # If neither new nor legacy inputs are provided, raise an error
+    raise FatalError("No components specified. Use 'components' input or legacy 'name'/'directories' inputs.")
 
 
 def upload_arguments() -> dict[str, str | None]:
@@ -192,6 +266,10 @@ def upload_components(
 
 def main() -> None:
     setup_environment_variables()
+
+    # Validate input precedence and provide migration guidance
+    validate_input_precedence()
+    provide_migration_guidance()
 
     workspace_path = Path(os.environ['GITHUB_WORKSPACE'])
 

--- a/upload.py
+++ b/upload.py
@@ -1,7 +1,9 @@
 #! /usr/bin/env python
 
 import os
+import random
 import re
+import string
 import subprocess
 import sys
 
@@ -117,7 +119,7 @@ def get_version_from_git() -> str:
     return str(result.stdout).strip().replace('v', '')
 
 
-MOCK_VERSION = '1000.1000.1000'
+MOCK_VERSION = f'1000.1000.1000-mock.{"".join(random.choices(string.ascii_lowercase, k=8))}'  # noqa: S311
 
 
 def mock_version_if_not_provided(args: dict[str, str | None], component_full_path: Path) -> dict[str, str | None]:


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

# Implement v1 to v2 Migration Support for Upload Components Action

## Overview
This MR implements complete backward compatibility support for the deprecated v1 inputs (`name` and `directories`) while maintaining full v2 functionality and providing helpful migration guidance to users.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Workflows with tests:

New syntax: https://github.com/kumekay/example_components/actions/runs/15531387967/job/43720927207
Old syntax (wrong): https://github.com/kumekay/example_components/actions/runs/15533127180/job/43726208984
Old syntax (correct):
https://github.com/kumekay/example_components/actions/runs/15533235840/job/43726541314


<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
