### PR TITLE
fix: Do not require token with dry-run

### DIFF
--- a/test_upload.py
+++ b/test_upload.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 import requests
 
-from upload import parse_components_input, split_component_str, Component, args_to_list, mock_version_if_not_provided, get_oidc_token, FatalError
+from upload import parse_components_input, split_component_str, Component, args_to_list, mock_version_if_not_provided, get_oidc_token, FatalError, ensure_token, MissingAuthConfigurationError
 from pathlib import Path
 
 @pytest.fixture
@@ -254,5 +254,29 @@ def test_get_oidc_token_success(monkeypatch):
 
 
 def test_get_oidc_without_permissions():
-    with pytest.raises(FatalError, match='set the permissions "id-token: write"'):
+    with pytest.raises(MissingAuthConfigurationError):
         get_oidc_token()
+
+
+def test_ensure_token(monkeypatch, capsys):
+    monkeypatch.setenv('IDF_COMPONENT_API_TOKEN', 'mocked_token')
+    ensure_token()
+    captured = capsys.readouterr()
+    assert captured.out == 'Using ESP Component Registry token.\n'
+
+def test_ensure_token_no_token(monkeypatch, capsys):
+    monkeypatch.delenv('IDF_COMPONENT_API_TOKEN', raising=False)
+    message = (
+        "Failed to authenticate: no valid token provided.\n"
+        "- If you intended to use the ESP Component Registry token, please set the 'api_token' "
+        "input in your workflow.\n"
+        "- If you intended to use GitHub OIDC for authentication, ensure that your workflow has "
+        "the required permissions:\n"
+        "  permissions:\n"
+        "    id-token: write\n"
+        "\n"
+        "Refer to the documentation for proper setup of authentication methods."
+    )
+
+    with pytest.raises(FatalError, match=message):
+        ensure_token()

--- a/upload.py
+++ b/upload.py
@@ -26,6 +26,12 @@ class FatalError(Exception):
     pass
 
 
+class MissingAuthConfigurationError(Exception):
+    """Raised when no valid authentication method (api_token or OIDC) is configured."""
+
+    pass
+
+
 @dataclass
 class Component:
     name: str | None
@@ -143,7 +149,7 @@ def get_oidc_token() -> str:
     registry_url = os.getenv('IDF_COMPONENT_REGISTRY_URL') or 'https://components.espressif.com'
 
     if not github_oidc_url or not github_token_request:
-        raise FatalError('Failed due to privileges. Please set the permissions "id-token: write" in the Github Action')
+        raise MissingAuthConfigurationError
 
     try:
         response = requests.get(
@@ -159,7 +165,7 @@ def get_oidc_token() -> str:
     oidc_token: str = response.json().get('value')
 
     if not oidc_token:
-        raise FatalError('Failed to revieve an OIDC token.')
+        raise FatalError('Failed to receive an OIDC token.')
 
     return oidc_token
 
@@ -195,12 +201,6 @@ def upload_arguments() -> dict[str, str | None]:
     if version:
         version = version.strip().lower()
         upload_args['version'] = get_version_from_git() if version == 'git' else version
-
-    if not os.getenv('IDF_COMPONENT_API_TOKEN'):
-        print('Using OIDC token.')
-        os.environ['IDF_COMPONENT_API_TOKEN'] = get_oidc_token()
-    else:
-        print('Using ESP Component Registry token.')
 
     return upload_args
 
@@ -299,6 +299,31 @@ def upload_components(
         raise FatalError(f'Failed to upload components: {", ".join(failed_components)}')
 
 
+def ensure_token():
+    if os.getenv('IDF_COMPONENT_API_TOKEN'):
+        print('Using ESP Component Registry token.')
+        return
+
+    if getenv_bool('DRY_RUN'):
+        return
+
+    try:
+        os.environ['IDF_COMPONENT_API_TOKEN'] = get_oidc_token()
+        print('Using GitHub OIDC token.')
+    except MissingAuthConfigurationError as e:
+        raise FatalError(
+            'Failed to authenticate: no valid token provided.\n'
+            "- If you intended to use the ESP Component Registry token, please set the 'api_token' "
+            'input in your workflow.\n'
+            '- If you intended to use GitHub OIDC for authentication, ensure that your workflow has '
+            'the required permissions:\n'
+            '  permissions:\n'
+            '    id-token: write\n'
+            '\n'
+            'Refer to the documentation for proper setup of authentication methods.'
+        ) from e
+
+
 def main() -> None:
     setup_environment_variables()
 
@@ -317,6 +342,7 @@ def main() -> None:
         return
 
     try:
+        ensure_token()
         upload_components(
             workspace_path=workspace_path,
             components=components,


### PR DESCRIPTION
This MR fixes a case, where a token was required with dry-run.

- Prints nice output instead of stack trace in case of OIDC fails

## Testing

Added tests + https://github.com/XDanielPaul/test/actions/runs/16119809439/job/45482431518

---